### PR TITLE
Add in interpolation feature for kwargs parsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,8 +33,9 @@ julia = "1.7"
 
 [extras]
 AtomsBaseTesting = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AtomsBaseTesting", "StaticArrays", "Test"]
+test = ["AtomsBaseTesting", "LinearAlgebra", "StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AiidaDFTK"
 uuid = "26386dbc-b74b-4d9a-b75a-41d28ada84fc"
 authors = ["Michael F. Herbst <info@michael-herbst.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -75,7 +75,8 @@ function run_self_consistent_field(data, system, basis)
 
     # TODO there is a way to write periodic checkpoints ...
 
-    kwargs = parse_kwargs(data["scf"]["\$kwargs"])
+    interpolations = Dict("basis" => basis, "model" => basis.model)
+    kwargs = parse_kwargs(data["scf"]["\$kwargs"]; interpolations)
     scfres = self_consistent_field(basis; ρ, ψ, kwargs...)
 
     store_slim = get(data["scf"], "store_slim", mpi_nprocs() > 1)

--- a/src/parse_kwargs.jl
+++ b/src/parse_kwargs.jl
@@ -1,30 +1,33 @@
-parse_kwargs_value(value) = value
-function parse_kwargs_value(value::AbstractString)
-    # Interpret string as symbol
-    startswith(value, ":") ? Symbol(value[2:end]) : value
+parse_kwargs_value(value; kwargs...) = value
+function parse_kwargs_value(value::AbstractString; interpolations::AbstractDict)
+    if startswith(value, ":")
+        Symbol(value[2:end])  # Interpret string as symbol
+    elseif startswith(value, "\$")
+        interpolations[value[2:end]]  # Lookup an interpolation
+    else
+        value
+    end
 end
-function parse_kwargs_value(value::AbstractVector)
-    parse_kwargs_value.(value)
+function parse_kwargs_value(value::AbstractVector; interpolations::AbstractDict)
+    parse_kwargs_value.(value; interpolations)
+end
+function parse_kwargs_value(value::AbstractDict; interpolations::AbstractDict)
+    # Lookup symbol and construct object
+    if startswith(value["\$symbol"], "Smearing.")
+        # TODO Horrible special-casing to get smearing to work
+        symbol = getproperty(DFTK.Smearing, Symbol(value["\$symbol"][10:end]))
+    else
+        symbol = getproperty(DFTK, Symbol(value["\$symbol"]))
+    end
+    args   = parse_kwargs_value.(get(value, "\$args", ()); interpolations)
+    kwargs = parse_kwargs(get(value, "\$kwargs", Dict()); interpolations)
+    symbol(args...; kwargs...)
 end
 
-function parse_kwargs(kwargs::AbstractDict)
+function parse_kwargs(kwargs::AbstractDict; interpolations=Dict{String,Any}())
     parsed = Dict{Symbol, Any}()
     for (key, value) in pairs(kwargs)
-        if value isa AbstractDict
-            # Lookup symbol and construct object
-            if startswith(value["\$symbol"], "Smearing.")
-                # TODO Horrible special-casing to get smearing to work
-                symbol = getproperty(DFTK.Smearing, Symbol(value["\$symbol"][10:end]))
-            else
-                symbol = getproperty(DFTK, Symbol(value["\$symbol"]))
-            end
-            args   = get(value, "\$args", ())
-            kwargs = parse_kwargs(get(value, "\$kwargs", Dict()))
-
-            parsed[Symbol(key)] = symbol(args...; kwargs...)
-        else
-            parsed[Symbol(key)] = parse_kwargs_value(value)
-        end
+        parsed[Symbol(key)] = parse_kwargs_value(value; interpolations)
     end
     parsed
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using AtomsBase
 using AtomsBaseTesting
 using DFTK
 using JSON3
+using LinearAlgebra
 using StaticArrays
 using Test
 using Unitful
@@ -30,6 +31,16 @@ using UnitfulAtomic
                                        "\$args" => [2]))
         ref = Dict(:smearing => DFTK.Smearing.MethfesselPaxton(2))
         @test parse_kwargs(data) == ref
+    end
+
+    @testset "parse_kwargs with interpolations" begin
+        model = Model(Matrix(I, 3, 3); n_electrons=4)
+        interpolations = Dict("model" => model, )
+        data = Dict("nbandsalg" => Dict("\$symbol" => "AdaptiveBands",
+                                        "\$args"   => ["\$model"],
+                                        "\$kwargs" => Dict("n_bands_converge" => 8, )))
+        ref = Dict(:nbandsalg => DFTK.AdaptiveBands(model; n_bands_converge=8))
+        @test parse_kwargs(data; interpolations) == ref
     end
 
     @testset "build_system" begin

--- a/test/silicon_slim.json
+++ b/test/silicon_slim.json
@@ -69,6 +69,13 @@
             "mixing": {
                  "$symbol": "KerkerDosMixing"
             },
+            "nbandsalg": {
+                 "$symbol": "AdaptiveBands",
+                 "$args": ["$model"],
+                 "$kwargs": {
+                     "n_bands_converge": 8
+                 }
+            },
             "is_converged": {
                  "$symbol": "ScfConvergenceEnergy",
                  "$args": 1.0e-4


### PR DESCRIPTION
CC @WuyihanVictor

The way to use this is to add to the scf "$kwargs":
```json
            "nbandsalg": {
                 "$symbol": "AdaptiveBands",
                 "$args": ["$model"],
                 "$kwargs": {
                     "n_bands_converge": 8
                 }
            },
```