### PR TITLE
Remove compute_stresses_cart precompilation to fix ForwardDiff Dual tag ordering problems

### DIFF
--- a/precompilation_task.json
+++ b/precompilation_task.json
@@ -1,0 +1,87 @@
+{
+    "periodic_system": {
+        "bounding_box": [
+            [
+                0.0,
+                5.1315509220433,
+                5.1315509220433
+            ],
+            [
+                5.1315509220433,
+                0.0,
+                5.1315509220433
+            ],
+            [
+                5.1315509220433,
+                5.1315509220433,
+                0.0
+            ]
+        ],
+        "atoms": [
+            {
+                "symbol": "Si",
+                "position": [
+                    1.282887730510825,
+                    1.282887730510825,
+                    1.282887730510825
+                ],
+                "pseudopotential": "hgh/lda/si-q4"
+            },
+            {
+                "symbol": "Si",
+                "position": [
+                    -1.282887730510825,
+                    -1.282887730510825,
+                    -1.282887730510825
+                ],
+                "pseudopotential": "hgh/lda/si-q4"
+            }
+        ]
+    },
+    "model_kwargs": {
+        "functionals": [
+            ":lda_x",
+            ":lda_c_pw"
+        ],
+        "temperature": 0.001,
+        "smearing": {
+            "$symbol": "Smearing.Gaussian"
+        }
+    },
+    "basis_kwargs": {
+        "kgrid": [
+            2,
+            2,
+            2
+        ],
+        "Ecut": 10
+    },
+    "scf_parameters": {
+        "tol": 1.0e-8,
+        "damping": null,
+        "mixing": null
+    },
+    "scf": {
+        "$function": "self_consistent_field",
+        "checkpointfile": "scfres.jld2",
+        "save_ψ": true,
+        "$kwargs": {
+            "mixing": {
+                 "$symbol": "KerkerDosMixing"
+            },
+            "nbandsalg": {
+                 "$symbol": "AdaptiveBands",
+                 "$args": ["$model"],
+                 "$kwargs": {
+                     "n_bands_converge": 8
+                 }
+            },
+            "is_converged": {
+                 "$symbol": "ScfConvergenceEnergy",
+                 "$args": 1.0e-4
+            }
+        }
+    },
+    "postscf": [
+    ]
+}

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -200,7 +200,11 @@ end
 
 # Precompilation block with a basic workflow
 @setup_workload begin
-    inputfile = joinpath(@__DIR__, "..", "test", "silicon_bands.json")
+    # Run a sample silicon input.
+    # We don't run any postscf derivative computation in the precompilation workload
+    # because of a bad interaction between ForwardDiff and the compilation cache:
+    # https://github.com/JuliaDiff/ForwardDiff.jl/issues/714
+    inputfile = joinpath(@__DIR__, "..", "precompilation_task.json")
 
     if !PrecompileTools.verbose[]
         # In verbose precompile mode also show the output here


### PR DESCRIPTION
Workaround for https://github.com/JuliaDiff/ForwardDiff.jl/issues/714. The `precompilation_task.json` file is just `test/silicon_bands.json` without the postscf... I didn't give it more thought for now.