### PR TITLE
Don't modify preferences automatically

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -27,7 +26,6 @@ DocStringExtensions = "0.9"
 HDF5 = "0.17"
 JLD2 = "0.4, 0.5"
 JSON3 = "1"
-LinearAlgebra = "1.10"
 MPI = "0.20"
 PrecompileTools = "1"
 TimerOutputs = "0.5"
@@ -38,8 +36,9 @@ julia = "1.10"
 [extras]
 AtomsBaseTesting = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AtomsBaseTesting", "HDF5", "StaticArrays", "Test"]
+test = ["AtomsBaseTesting", "HDF5", "LinearAlgebra", "StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -26,6 +27,7 @@ DocStringExtensions = "0.9"
 HDF5 = "0.17"
 JLD2 = "0.4, 0.5"
 JSON3 = "1"
+LinearAlgebra = "1.10"
 MPI = "0.20"
 PrecompileTools = "1"
 TimerOutputs = "0.5"
@@ -36,9 +38,8 @@ julia = "1.10"
 [extras]
 AtomsBaseTesting = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AtomsBaseTesting", "HDF5", "LinearAlgebra", "StaticArrays", "Test"]
+test = ["AtomsBaseTesting", "HDF5", "StaticArrays", "Test"]

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -31,7 +31,6 @@ include("store_hdf5.jl")
 
 # Helper function to check whether we are on the master process
 mpi_master(comm=MPI.COMM_WORLD) = (MPI.Init(); MPI.Comm_rank(comm) == 0)
-mpi_nprocs(comm=MPI.COMM_WORLD) = (MPI.Init(); MPI.Comm_size(comm))
 
 function build_system(data)
     atoms = map(data["periodic_system"]["atoms"]) do atom
@@ -127,15 +126,13 @@ function run_json(filename::AbstractString; extra_output_files=String[])
 
     # Threading setup ... maybe later need to take parameters
     # from the JSON into account
-    if mpi_nprocs() > 1
-        DFTK.setup_threading(; n_blas=1, n_fft=1)
-        # Don't modify DFTK threads automatically.
-        # They are controlled by a preference, changing it can trigger a recompilation!
-        # The best we can do is warn the user.
-        if DFTK.get_DFTK_threads() > 1
-            @warn("Running through MPI, but threading was not disabled!"
-                + " DFTK threads: $(DFTK.get_DFTK_threads()).")
-        end
+    DFTK.setup_threading(; n_blas=1, n_fft=1)
+    # Don't modify DFTK threads automatically.
+    # They are controlled by a preference, changing it can trigger a recompilation!
+    # The best we can do is warn the user.
+    if DFTK.get_DFTK_threads() > 1
+        @warn("Running through MPI, but threading was not disabled!"
+            * " DFTK threads: $(DFTK.get_DFTK_threads()).")
     end
 
     DFTK.reset_timer!(DFTK.timer)

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -6,7 +6,6 @@ using DocStringExtensions
 using InteractiveUtils
 using JLD2
 using JSON3
-using LinearAlgebra
 using Logging
 using MPI
 using Pkg
@@ -129,13 +128,14 @@ function run_json(filename::AbstractString; extra_output_files=String[])
     # Threading setup ... maybe later need to take parameters
     # from the JSON into account
     if mpi_nprocs() > 1
-        # Julia threads are controlled when launching Julia and should be disabled by the user.
-        if Threads.nthreads() > 1
+        DFTK.setup_threading(; n_blas=1, n_fft=1)
+        # Don't modify DFTK threads automatically.
+        # They are controlled by a preference, changing it can trigger a recompilation!
+        # The best we can do is warn the user.
+        if DFTK.get_DFTK_threads() > 1
             @warn("Running through MPI, but threading was not disabled!"
-                + " Julia threads: $(Threads.nthreads()).")
+                + " DFTK threads: $(DFTK.get_DFTK_threads()).")
         end
-        # BLAS threads are controlled separately and can be disabled at runtime.
-        BLAS.set_num_threads(1)
     end
 
     DFTK.reset_timer!(DFTK.timer)

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -6,6 +6,7 @@ using DocStringExtensions
 using InteractiveUtils
 using JLD2
 using JSON3
+using LinearAlgebra
 using Logging
 using MPI
 using Pkg
@@ -128,9 +129,13 @@ function run_json(filename::AbstractString; extra_output_files=String[])
     # Threading setup ... maybe later need to take parameters
     # from the JSON into account
     if mpi_nprocs() > 1
-        disable_threading()
-    else
-        setup_threading()
+        # Julia threads are controlled when launching Julia and should be disabled by the user.
+        if Threads.nthreads() > 1
+            @warn("Running through MPI, but threading was not disabled!"
+                + " Julia threads: $(Threads.nthreads()).")
+        end
+        # BLAS threads are controlled separately and can be disabled at runtime.
+        BLAS.set_num_threads(1)
     end
 
     DFTK.reset_timer!(DFTK.timer)


### PR DESCRIPTION
Modifying preferences will trigger a recompilation on the next load. This can cause unexpected problems when combined with MPI runs or when done while precompiling. Personal opinion: we should **never** change a preference automatically, but we can warn/error when a misconfiguration is detected.